### PR TITLE
deprecate svg prop, refactor to getSvg in utils.js

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,3 +7,4 @@ npm-debug.log
 /icons.js
 /icons.mjs
 /icons.d.ts
+/utils.js

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /icons.js
 /icons.mjs
 /icons.d.ts
+/utils.js
 
 # Ignore all files in the icons folder
 icons/*

--- a/.npmignore
+++ b/.npmignore
@@ -13,3 +13,6 @@
 !icons.js
 !icons.mjs
 !icons.d.ts
+!utils.js
+!utils.mjs
+!utils.d.ts

--- a/.svglintrc.mjs
+++ b/.svglintrc.mjs
@@ -1,12 +1,10 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import {
-  getDirnameFromImportMeta,
-  htmlFriendlyToTitle,
-} from './scripts/utils.js';
 import svgpath from 'svgpath';
 import svgPathBbox from 'svg-path-bbox';
 import parsePath from 'svg-path-segments';
+import { getDirnameFromImportMeta } from './scripts/utils.js';
+import { htmlFriendlyToTitle } from './utils.mjs';
 
 const __dirname = getDirnameFromImportMeta(import.meta.url);
 const dataFile = path.join(__dirname, '_data', 'simple-icons.json');

--- a/README.md
+++ b/README.md
@@ -72,7 +72,6 @@ console.log(siSimpleicons);
     slug: 'simpleicons',
     hex: '111111',
     source: 'https://simpleicons.org/',
-    svg: '<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">...</svg>',
     path: 'M12 12v-1.5c-2.484 ...',
     guidelines: 'https://simpleicons.org/styleguide',
     license: {
@@ -84,6 +83,14 @@ console.log(siSimpleicons);
 NOTE: the `guidelines` entry will be `undefined` if we do not yet have guidelines for the icon.
 NOTE: the `license` entry will be `undefined` if we do not yet have license data for the icon.
 */
+```
+
+You can get the SVG string for an icon like so:
+```javascript
+import { siSimpleicons } from 'simple-icons/icons';
+import { getSvg } from 'simple-icons/utils';
+
+const svg = getSvg(siSimpleIcons);
 ```
 
 #### TypeScript Usage <img src="https://raw.githubusercontent.com/simple-icons/simple-icons/develop/icons/typescript.svg#gh-light-mode-only" alt="Typescript" align=left width=19 height=19><img src="https://raw.githubusercontent.com/simple-icons/simple-icons/develop/assets/readme/typescript-white.svg#gh-dark-mode-only" alt="Typescript" align=left width=19 height=19>

--- a/a.mjs
+++ b/a.mjs
@@ -1,0 +1,5 @@
+import { getSvg } from './utils.mjs';
+import { siAwslambda } from './icons.mjs';
+const svg = getSvg(siAwslambda);
+
+console.log(svg);

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,9 @@
 export interface SimpleIcon {
   title: string;
   slug: string;
+  /**
+   * @deprecated The `svg` property will be removed in the next major. Please use `import { getSvg } from "simple-icons/utils"` instead.
+   */
   svg: string;
   path: string;
   source: string;

--- a/package.json
+++ b/package.json
@@ -20,7 +20,13 @@
     },
     "./icons/*": [
       "./icons/*"
-    ]
+    ],
+    "./utils": {
+      "module": "./utils.mjs",
+      "import": "./utils.mjs",
+      "require": "./utils.js",
+      "default": "./utils.js"
+    }
   },
   "sideEffects": false,
   "repository": {

--- a/scripts/build/templates/icon-object.js
+++ b/scripts/build/templates/icon-object.js
@@ -2,7 +2,8 @@
   title: '%s',
   slug: '%s',
   get svg() {
-    return '<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>%s</title><path d="' + this.path + '"/></svg>';
+    d()
+    return getSvg(this)
   },
   path: '%s',
   source: '%s',

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -65,35 +65,6 @@ export const slugToVariableName = (slug) => {
 };
 
 /**
- * Converts a brand title (as it is seen in simple-icons.json) into a brand
- * title in HTML/SVG friendly format.
- * @param {String} brandTitle The title to convert
- */
-export const titleToHtmlFriendly = (brandTitle) =>
-  brandTitle
-    .replace(/&/g, '&amp;')
-    .replace(/"/g, '&quot;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/./g, (char) => {
-      const charCode = char.charCodeAt(0);
-      return charCode > 127 ? `&#${charCode};` : char;
-    });
-
-/**
- * Converts a brand title in HTML/SVG friendly format into a brand title (as
- * it is seen in simple-icons.json)
- * @param {String} htmlFriendlyTitle The title to convert
- */
-export const htmlFriendlyToTitle = (htmlFriendlyTitle) =>
-  htmlFriendlyTitle
-    .replace(/&#([0-9]+);/g, (_, num) => String.fromCharCode(parseInt(num)))
-    .replace(
-      /&(quot|amp|lt|gt);/g,
-      (_, ref) => ({ quot: '"', amp: '&', lt: '<', gt: '>' }[ref]),
-    );
-
-/**
  * Get contents of _data/simple-icons.json.
  * @param {String|undefined} rootDir Path to the root directory of the project.
  */

--- a/tests/icons.test.js
+++ b/tests/icons.test.js
@@ -6,14 +6,14 @@ import {
 import * as simpleIcons from '../icons.mjs';
 import { testIcon } from './test-icon.js';
 
-(async () => {
-  const icons = await getIconsData();
+console.warn = () => {};
 
-  icons.map((icon) => {
-    const slug = getIconSlug(icon);
-    const variableName = slugToVariableName(slug);
-    const subject = simpleIcons[variableName];
+const icons = await getIconsData();
 
-    testIcon(icon, subject, slug);
-  });
-})();
+icons.map((icon) => {
+  const slug = getIconSlug(icon);
+  const variableName = slugToVariableName(slug);
+  const subject = simpleIcons[variableName];
+
+  testIcon(icon, subject, slug);
+});

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -3,35 +3,35 @@ import { getIconSlug, getIconsData, titleToSlug } from '../scripts/utils.js';
 import { test } from 'mocha';
 import { strict as assert } from 'node:assert';
 
-(async () => {
-  const icons = await getIconsData();
+console.warn = () => {};
 
-  icons.forEach((icon) => {
-    const slug = getIconSlug(icon);
+const icons = await getIconsData();
 
-    test(`'Get' ${icon.title} by its slug`, () => {
-      const found = simpleIcons.Get(slug);
-      assert.ok(found);
-      assert.equal(found.title, icon.title);
-      assert.equal(found.hex, icon.hex);
-      assert.equal(found.source, icon.source);
+icons.forEach((icon) => {
+  const slug = getIconSlug(icon);
+
+  test(`'Get' ${icon.title} by its slug`, () => {
+    const found = simpleIcons.Get(slug);
+    assert.ok(found);
+    assert.equal(found.title, icon.title);
+    assert.equal(found.hex, icon.hex);
+    assert.equal(found.source, icon.source);
+  });
+
+  if (icon.slug) {
+    // if an icon data has a slug, it must be different to the
+    // slug inferred from the title, which prevents adding
+    // unnecessary slugs to icons data
+    test(`'${icon.title}' slug must be necessary`, () => {
+      assert.notEqual(titleToSlug(icon.title), icon.slug);
     });
+  }
+});
 
-    if (icon.slug) {
-      // if an icon data has a slug, it must be different to the
-      // slug inferred from the title, which prevents adding
-      // unnecessary slugs to icons data
-      test(`'${icon.title}' slug must be necessary`, () => {
-        assert.notEqual(titleToSlug(icon.title), icon.slug);
-      });
-    }
-  });
-
-  test(`Iterating over simpleIcons only exposes icons`, () => {
-    const iconArray = Object.values(simpleIcons);
-    for (let icon of iconArray) {
-      assert.ok(icon);
-      assert.equal(typeof icon, 'object');
-    }
-  });
-})();
+test(`Iterating over simpleIcons only exposes icons`, () => {
+  const iconArray = Object.values(simpleIcons);
+  for (let icon of iconArray) {
+    assert.ok(icon);
+    assert.equal(typeof icon, 'object');
+  }
+});

--- a/tests/test-icon.js
+++ b/tests/test-icon.js
@@ -2,6 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { strict as assert } from 'node:assert';
 import { describe, it } from 'mocha';
+import { getSvg } from '../utils.mjs';
 
 const iconsDir = path.resolve(process.cwd(), 'icons');
 
@@ -65,6 +66,7 @@ export const testIcon = (icon, subject, slug) => {
         .readFileSync(svgPath, 'utf8')
         .replace(/\r?\n/, '');
       assert.equal(subject.svg, svgFileContents);
+      assert.equal(getSvg(subject), svgFileContents);
     });
   });
 };

--- a/utils.d.ts
+++ b/utils.d.ts
@@ -1,0 +1,20 @@
+import { SimpleIcon } from '.';
+
+/**
+ * Converts a brand title (as it is seen in simple-icons.json) into a brand
+ * title in HTML/SVG friendly format.
+ * @param brandTitle The title to convert
+ */
+export declare const titleToHtmlFriendly: (brandTitle: string) => string;
+
+/**
+ * Converts a brand title in HTML/SVG friendly format into a brand title (as
+ * it is seen in simple-icons.json)
+ * @param htmlFriendlyTitle The title to convert
+ */
+export const htmlFriendlyToTitle = (htmlFriendlyTitle: string) => string;
+
+/**
+ * Gets the SVG string from an icon object.
+ */
+export declare const getSvg: (icon: SimpleIcon) => string;

--- a/utils.mjs
+++ b/utils.mjs
@@ -1,0 +1,33 @@
+/**
+ * Converts a brand title (as it is seen in simple-icons.json) into a brand
+ * title in HTML/SVG friendly format.
+ * @param {String} brandTitle The title to convert
+ */
+export const titleToHtmlFriendly = (brandTitle) =>
+  brandTitle
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/./g, (char) => {
+      const charCode = char.charCodeAt(0);
+      return charCode > 127 ? `&#${charCode};` : char;
+    });
+
+/**
+ * Converts a brand title in HTML/SVG friendly format into a brand title (as
+ * it is seen in simple-icons.json)
+ * @param {String} htmlFriendlyTitle The title to convert
+ */
+export const htmlFriendlyToTitle = (htmlFriendlyTitle) =>
+  htmlFriendlyTitle
+    .replace(/&#([0-9]+);/g, (_, num) => String.fromCharCode(parseInt(num)))
+    .replace(
+      /&(quot|amp|lt|gt);/g,
+      (_, ref) => ({ quot: '"', amp: '&', lt: '<', gt: '>' }[ref]),
+    );
+
+export const getSvg = (icon) =>
+  `<svg role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>${titleToHtmlFriendly(
+    icon.title,
+  )}</title><path d="${icon.path}"/></svg>`;


### PR DESCRIPTION
#7441 must be merged first

Replace the `icon.svg` property with a `getSvg` function imported from `import { getSvg } from 'simple-icons/utils'`. This will help lower bundle size.